### PR TITLE
Fixes for improved C99 compatibility

### DIFF
--- a/usb_replay.c
+++ b/usb_replay.c
@@ -18,6 +18,7 @@
 #include <string.h>
 #include <math.h>
 #include <assert.h>
+#include <unistd.h>
 #include <libusb.h>
 #include "common.h"
 #include "usb_replay.h"

--- a/usb_replay.h
+++ b/usb_replay.h
@@ -34,4 +34,8 @@ typedef struct urb_s {
 	uint16_t wLength;
 } urb_t;
 
+void usb_init(unsigned int vid, unsigned int pid);
+void perform_transfer(urb_t *urb);
+void print_help_and_exit(char **argv);
+
 #endif

--- a/usb_replay.y
+++ b/usb_replay.y
@@ -2,6 +2,7 @@
     #include <stdio.h>
     #include <stdlib.h>
     #include <string.h>
+    #include "common.h"
     #include "usb_replay.h"
     #include "error.h"
     int yylex(void);


### PR DESCRIPTION
Make available more function prototypes, to avoid implicit function declarations.  This improves compatibility with future compilers, which are likely to reject implicit function declarations.  (C99 removed implicit function declarations from the language.)

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
